### PR TITLE
made changes for owncloud 9 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV DATADIR=$MYSQL_DIR/database
 ENV BUILD_APTLIST="php7.0-dev" \
 APTLIST="exim4 exim4-base exim4-config exim4-daemon-light git-core heirloom-mailx jq libaio1 libapr1 \
 libaprutil1 libaprutil1-dbd-sqlite3 libaprutil1-ldap libdbd-mysql-perl libdbi-perl libfreetype6 \
-libmysqlclient18 libpcre3-dev libsmbclient.dev nano nginx openssl php7.0-bz2 php7.0-cli \
+libmysqlclient18 libpcre3-dev libsmbclient.dev nano nginx openssl php-apcu php7.0-bz2 php7.0-cli \
 php7.0-common php7.0-curl php7.0-fpm php7.0-gd php7.0-gmp php7.0-imap php7.0-intl php7.0-ldap \
 php7.0-mbstring php7.0-mcrypt php7.0-mysql php7.0-opcache php7.0-xml php7.0-xmlrpc php7.0-zip \
 php-imagick pkg-config smbclient re2c ssl-cert wget" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ phpize && \
 ./configure && \
 make && \
 make install && \
-# echo "extension=smbclient.so" > /etc/php/mods-available/smbclient.ini && \
+echo "extension=smbclient.so" > /etc/php/7.0/mods-available/smbclient.ini && \
 
 # install apcu 
 git clone https://github.com/krakjoe/apcu /tmp/apcu && \
@@ -52,9 +52,7 @@ phpize && \
 ./configure && \
 make && \
 make install && \
-#pecl channel-update pecl.php.net && \
-#pecl install apcu && \
-# echo "extension=apcu.so" > /etc/php/mods-available/apcu.ini && \
+echo "extension=apcu.so" > /etc/php/7.0/mods-available/apcu.ini && \
 
 # cleanup 
 cd / && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV DATADIR=$MYSQL_DIR/database
 ENV BUILD_APTLIST="php7.0-dev" \
 APTLIST="exim4 exim4-base exim4-config exim4-daemon-light git-core heirloom-mailx jq libaio1 libapr1 \
 libaprutil1 libaprutil1-dbd-sqlite3 libaprutil1-ldap libdbd-mysql-perl libdbi-perl libfreetype6 \
-libmysqlclient18 libpcre3-dev libsmbclient.dev nano nginx openssl php-apcu php7.0-bz2 php7.0-cli \
+libmysqlclient18 libpcre3-dev libsmbclient.dev nano nginx openssl php7.0-bz2 php7.0-cli \
 php7.0-common php7.0-curl php7.0-fpm php7.0-gd php7.0-gmp php7.0-imap php7.0-intl php7.0-ldap \
 php7.0-mbstring php7.0-mcrypt php7.0-mysql php7.0-opcache php7.0-xml php7.0-xmlrpc php7.0-zip \
 php-imagick pkg-config smbclient re2c ssl-cert wget" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ COPY init/ /etc/my_init.d/
 RUN chmod -v +x /etc/service/*/run /etc/my_init.d/*.sh && \
 
 # configure fpm for owncloud
-echo "env[PATH] = /usr/local/bin:/usr/bin:/bin" >> /defaults/nginx-fpm.conf && \
+echo "env[PATH] = /usr/local/bin:/usr/bin:/bin" >> /defaults/nginx-fpm.conf
 
 # expose ports
 EXPOSE 443

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ phpize && \
 ./configure && \
 make && \
 make install && \
-echo "extension=smbclient.so" > /etc/php/mods-available/smbclient.ini && \
+# echo "extension=smbclient.so" > /etc/php/mods-available/smbclient.ini && \
 
 # install apcu 
 git clone https://github.com/krakjoe/apcu /tmp/apcu && \
@@ -53,7 +53,7 @@ make && \
 make install && \
 #pecl channel-update pecl.php.net && \
 #pecl install apcu && \
-echo "extension=apcu.so" > /etc/php/mods-available/apcu.ini && \
+# echo "extension=apcu.so" > /etc/php/mods-available/apcu.ini && \
 
 # cleanup 
 cd / && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,14 @@ MAINTAINER Sparklyballs <sparklyballs@linuxserver.io>
 ENV MYSQL_DIR="/config"
 ENV DATADIR=$MYSQL_DIR/database
 
-ENV BUILD_APTLIST="php7.0-dev"
-ENV INSTALL_LIST="exim4 exim4-base exim4-config exim4-daemon-light git-core heirloom-mailx jq libaio1 libapr1 \
+ENV BUILD_APTLIST="php7.0-dev" \
+APTLIST="exim4 exim4-base exim4-config exim4-daemon-light git-core heirloom-mailx jq libaio1 libapr1 \
 libaprutil1 libaprutil1-dbd-sqlite3 libaprutil1-ldap libdbd-mysql-perl libdbi-perl libfreetype6 \
-libmysqlclient18 libpcre3-dev libsmbclient.dev mariadb-server mysql-common mysqltuner nano nginx \
-openssl php-apcu php7.0-bz2 php7.0-cli php7.0-common php7.0-curl php7.0-fpm php7.0-gd php7.0-gmp php7.0-imap php7.0-intl \
-php7.0-ldap php7.0-mbstring php7.0-mcrypt php7.0-mysql php7.0-opcache php7.0-xml php7.0-xmlrpc php7.0-zip php-imagick \
-pkg-config smbclient re2c ssl-cert wget"
+libmysqlclient18 libpcre3-dev libsmbclient.dev nano nginx openssl php-apcu php7.0-bz2 php7.0-cli \
+php7.0-common php7.0-curl php7.0-fpm php7.0-gd php7.0-gmp php7.0-imap php7.0-intl php7.0-ldap \
+php7.0-mbstring php7.0-mcrypt php7.0-mysql php7.0-opcache php7.0-xml php7.0-xmlrpc php7.0-zip \
+php-imagick pkg-config smbclient re2c ssl-cert wget" \
+DB_APTLIST="mariadb-server mysqltuner"
 
 # add repositories
 RUN \
@@ -33,7 +34,7 @@ add-apt-repository ppa:fkrull/deadsnakes-python2.7
 # install packages
 RUN apt-get update -q && \
 apt-get install \
-$INSTALL_LIST $BUILD_APTLIST -qy && \
+$DB_APTLIST $APTLIST $BUILD_APTLIST -qy && \
 
 # build libsmbclient support
 git clone git://github.com/eduardok/libsmbclient-php.git /tmp/smbclient && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,22 +63,13 @@ rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/lib/mysql && \
 mkdir -p /var/lib/mysql
 
 # add some files 
-ADD services/ /etc/service/
-ADD defaults/ /defaults/
-ADD init/ /etc/my_init.d/
+COPY services/ /etc/service/
+COPY  defaults/ /defaults/
+COPY init/ /etc/my_init.d/
 RUN chmod -v +x /etc/service/*/run /etc/my_init.d/*.sh && \
 
 # configure fpm for owncloud
 echo "env[PATH] = /usr/local/bin:/usr/bin:/bin" >> /defaults/nginx-fpm.conf && \
-
-# configure mariadb
-sed -i 's/key_buffer\b/key_buffer_size/g' /etc/mysql/my.cnf && \
-sed -ri 's/^(bind-address|skip-networking)/;\1/' /etc/mysql/my.cnf && \
-sed -i s#/var/log/mysql#/config/log/mysql#g /etc/mysql/my.cnf && \
-sed -i -e 's/\(user.*=\).*/\1 abc/g' /etc/mysql/my.cnf && \
-sed -i -e "s#\(datadir.*=\).*#\1 $DATADIR#g" /etc/mysql/my.cnf && \
-sed -i "s/user='mysql'/user='abc'/g" /usr/bin/mysqld_safe && \
-cp /etc/mysql/my.cnf /defaults/my.cnf
 
 # expose ports
 EXPOSE 443

--- a/READMETEMPLATE.md
+++ b/READMETEMPLATE.md
@@ -1,6 +1,9 @@
-![http://linuxserver.io](http://www.linuxserver.io/wp-content/uploads/2015/06/linuxserver_medium.png)
+![https://linuxserver.io](https://www.linuxserver.io/wp-content/uploads/2015/06/linuxserver_medium.png)
 
-The [LinuxServer.io](https://www.linuxserver.io/) team brings you another quality container release featuring auto-update on startup, easy user mapping and community support. Be sure to checkout our [forums](https://forum.linuxserver.io/index.php) or for real-time support our [IRC](https://www.linuxserver.io/index.php/irc/) on freenode at `#linuxserver.io`.
+The [LinuxServer.io](https://linuxserver.io) team brings you another container release featuring auto-update on startup, easy user mapping and community support. Find us for support at:
+* [forum.linuxserver.io](https://forum.linuxserver.io)
+* [IRC](https://www.linuxserver.io/index.php/irc/) on freenode at `#linuxserver.io`
+* [Podcast](https://www.linuxserver.io/index.php/category/podcast/) covers everything to do with getting the most from your Linux Server plus a focus on all things Docker and containerisation!
 
 # linuxserver/owncloud
 OwnCloud provides universal access to your files via the web, your computer or your mobile devices — wherever you are. Mariadb 10.1 is built into the image. Built with php7, mariadb 10.1 and nginx 1.9.10. [Owncloud.](https://owncloud.org/)
@@ -25,13 +28,17 @@ docker create --name=owncloud -v <path to config>:/config \
 * `-e TZ` timezone information -eg Europe/London
 * `-e DB_PASS` owncloud database password - see below for explanation
 
-It is based on phusion-baseimage with ssh removed, for shell access whilst the container is running do `docker exec -it owncloud /bin/bash`.
 
 ### User / Group Identifiers
 
-**TL;DR** - The `PGID` and `PUID` values set the user / group you'd like your container to 'run as' to the host OS. This can be a user you've created or even root (not recommended).
+Sometimes when using data volumes (`-v` flags) permissions issues can arise between the host OS and the container. We avoid this issue by allowing you to specify the user `PUID` and group `PGID`. Ensure the data volume directory on the host is owned by the same user you specify and it will "just work" ™.
 
-Part of what makes our containers work so well is by allowing you to specify your own `PUID` and `PGID`. This avoids nasty permissions errors with relation to data volumes (`-v` flags). When an application is installed on the host OS it is normally added to the common group called users, Docker apps due to the nature of the technology can't be added to this group. So we added this feature to let you easily choose when running your containers.
+In this instance `PUID=1001` and `PGID=1001`. To find yours use `id user` as below:
+
+```
+  $ id <dockeruser>
+    uid=1001(dockeruser) gid=1001(dockergroup) groups=1001(dockergroup)
+```
 
 ## Setting up the application
 * initial webui startup, enter a username and password you want for your user in the setup screen.
@@ -42,12 +49,14 @@ Part of what makes our containers work so well is by allowing you to specify you
 
 ## Updates
 
-* Update owncloud through the webui
-* To monitor the logs of the container in realtime `docker logs -f owncloud`.
+* Shell access whilst the container is running: `docker exec -it container-name /bin/bash`
+* Upgrade owncloud from the webui, `Daily branch does not work, so just don't...`
+* To monitor the logs of the container in realtime: `docker logs -f owncloud`
 
 
 
 ## Versions
 
 + **dd.MM.yyyy:** Initial Release.
+
 

--- a/defaults/default
+++ b/defaults/default
@@ -1,6 +1,6 @@
 upstream php-handler {
   server 127.0.0.1:9000;
-  #server unix:/var/run/php5-fpm.sock;
+server unix:/var/run/php/php7.0-fpm.sock;
 }
 
 server {

--- a/defaults/default
+++ b/defaults/default
@@ -1,26 +1,30 @@
 upstream php-handler {
   server 127.0.0.1:9000;
-  server unix:/var/run/php/php7.0-fpm.sock;
-  }
+  #server unix:/var/run/php5-fpm.sock;
+}
 
 server {
   listen 80;
   server_name _;
   # enforce https
   return 301 https://$server_name$request_uri;
-  }
+}
 
 server {
   listen 443 ssl;
   server_name _;
+
   ssl_certificate /config/keys/cert.crt;
   ssl_certificate_key /config/keys/cert.key;
+
   # Add headers to serve security related headers
   add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;";
   add_header X-Content-Type-Options nosniff;
   add_header X-Frame-Options "SAMEORIGIN";
   add_header X-XSS-Protection "1; mode=block";
   add_header X-Robots-Tag none;
+  add_header X-Download-Options noopen;
+  add_header X-Permitted-Cross-Domain-Policies none;
 
   # Path to the root of your installation
   root /config/www/owncloud/;
@@ -35,53 +39,70 @@ server {
   # This module is currently not supported.
   #pagespeed off;
 
-  rewrite ^/caldav(.*)$ /remote.php/caldav$1 redirect;
-  rewrite ^/carddav(.*)$ /remote.php/carddav$1 redirect;
-  rewrite ^/webdav(.*)$ /remote.php/webdav$1 redirect;
-
   index index.php;
   error_page 403 /core/templates/403.php;
   error_page 404 /core/templates/404.php;
+
+  rewrite ^/.well-known/carddav /remote.php/dav/ permanent;
+  rewrite ^/.well-known/caldav /remote.php/dav/ permanent;
+
+  # The following 2 rules are only needed for the user_webfinger app.
+  # Uncomment it if you're planning to use this app.
+  #rewrite ^/.well-known/host-meta /public.php?service=host-meta last;
+  #rewrite ^/.well-known/host-meta.json /public.php?service=host-meta-json last;
 
   location = /robots.txt {
     allow all;
     log_not_found off;
     access_log off;
-    }
-
-  location ~ ^/(?:\.htaccess|data|config|db_structure\.xml|README){
-    deny all;
-    }
-
-  location / {
-   # The following 2 rules are only needed with webfinger
-   rewrite ^/.well-known/host-meta /public.php?service=host-meta last;
-   rewrite ^/.well-known/host-meta.json /public.php?service=host-meta-json last;
-
-   rewrite ^/.well-known/carddav /remote.php/carddav/ redirect;
-   rewrite ^/.well-known/caldav /remote.php/caldav/ redirect;
-
-   rewrite ^(/core/doc/[^\/]+/)$ $1/index.html;
-
-   try_files $uri $uri/ /index.php;
-   }
-
-   location ~ \.php(?:$|/) {
-   fastcgi_split_path_info ^(.+\.php)(/.+)$;
-   include /etc/nginx/fastcgi_params;
-   fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-   fastcgi_param PATH_INFO $fastcgi_path_info;
-   fastcgi_param HTTPS on;
-   fastcgi_param modHeadersAvailable true; #Avoid sending the security headers twice
-   fastcgi_pass php-handler;
-   }
-
-   # Optional: set long EXPIRES header on static assets
-   location ~* \.(?:jpg|jpeg|gif|bmp|ico|png|css|js|swf)$ {
-       expires 30d;
-       # Optional: Don't log access to assets
-         access_log off;
-   }
-
   }
 
+  location ~ ^/(build|tests|config|lib|3rdparty|templates|data)/ {
+    deny all;
+  }
+
+  location ~ ^/(?:\.|autotest|occ|issue|indie|db_|console) {
+    deny all;
+  }
+
+  location / {
+
+    rewrite ^/remote/(.*) /remote.php last;
+
+    rewrite ^(/core/doc/[^\/]+/)$ $1/index.html;
+
+    try_files $uri $uri/ =404;
+  }
+
+  location ~ \.php(?:$|/) {
+    fastcgi_split_path_info ^(.+\.php)(/.+)$;
+    include /etc/nginx/fastcgi_params;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    fastcgi_param PATH_INFO $fastcgi_path_info;
+    fastcgi_param HTTPS on;
+    fastcgi_param modHeadersAvailable true; #Avoid sending the security headers twice
+    fastcgi_pass php-handler;
+    fastcgi_intercept_errors on;
+  }
+
+  # Adding the cache control header for js and css files
+  # Make sure it is BELOW the location ~ \.php(?:$|/) { block
+  location ~* \.(?:css|js)$ {
+    add_header Cache-Control "public, max-age=7200";
+    # Add headers to serve security related headers
+    add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;";
+    add_header X-Content-Type-Options nosniff;
+    add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-XSS-Protection "1; mode=block";
+    add_header X-Robots-Tag none;
+    add_header X-Download-Options noopen;
+    add_header X-Permitted-Cross-Domain-Policies none;
+    # Optional: Don't log access to assets
+    access_log off;
+  }
+
+  # Optional: Don't log access to other assets
+  location ~* \.(?:jpg|jpeg|gif|bmp|ico|png|swf)$ {
+    access_log off;
+  }
+}

--- a/defaults/my.cnf
+++ b/defaults/my.cnf
@@ -1,0 +1,142 @@
+## custom configuration file, please be aware that changing options here may break things
+
+[mysqld_safe]
+nice		= 0
+
+[mysqld]
+max_connections		= 100
+connect_timeout		= 5
+wait_timeout		= 600
+max_allowed_packet	= 16M
+thread_cache_size       = 128
+sort_buffer_size	= 4M
+bulk_insert_buffer_size	= 16M
+tmp_table_size		= 32M
+max_heap_table_size	= 32M
+#
+# * MyISAM
+#
+# This replaces the startup script and checks MyISAM tables if needed
+# the first time they are touched. On error, make copy and try a repair.
+myisam_recover_options = BACKUP
+key_buffer_size		= 128M
+#open-files-limit	= 2000
+table_open_cache	= 400
+myisam_sort_buffer_size	= 512M
+concurrent_insert	= 2
+read_buffer_size	= 2M
+read_rnd_buffer_size	= 1M
+#
+# * Query Cache Configuration
+#
+# Cache only tiny result sets, so we can fit more in the query cache.
+query_cache_limit		= 128K
+query_cache_size		= 64M
+# for more write intensive setups, set to DEMAND or OFF
+#query_cache_type		= DEMAND
+#
+# * Logging and Replication
+#
+# Both location gets rotated by the cronjob.
+# Be aware that this log type is a performance killer.
+# As of 5.1 you can enable the log at runtime!
+#general_log_file        = /config/log/mysql/mysql.log
+#general_log             = 1
+#
+# Error logging goes to syslog due to /etc/mysql/conf.d/mysqld_safe_syslog.cnf.
+#
+# we do want to know about network errors and such
+log_warnings		= 2
+#
+# Enable the slow query log to see queries with especially long duration
+#slow_query_log[={0|1}]
+slow_query_log_file	= /config/log/mysql/mariadb-slow.log
+long_query_time = 10
+#log_slow_rate_limit	= 1000
+log_slow_verbosity	= query_plan
+
+#log-queries-not-using-indexes
+#log_slow_admin_statements
+#
+# The following can be used as easy to replay backup logs or for replication.
+# note: if you are setting up a replication slave, see README.Debian about
+#       other settings you may need to change.
+#server-id		= 1
+#report_host		= master1
+#auto_increment_increment = 2
+#auto_increment_offset	= 1
+log_bin			= /config/log/mysql/mariadb-bin
+log_bin_index		= /config/log/mysql/mariadb-bin.index
+# not fab for performance, but safer
+#sync_binlog		= 1
+expire_logs_days	= 10
+max_binlog_size         = 100M
+# slaves
+#relay_log		= /config/log/mysql/relay-bin
+#relay_log_index	= /config/log/mysql/relay-bin.index
+#relay_log_info_file	= /config/log/mysql/relay-bin.info
+#log_slave_updates
+#read_only
+#
+# If applications support it, this stricter sql_mode prevents some
+# mistakes like inserting invalid dates etc.
+#sql_mode		= NO_ENGINE_SUBSTITUTION,TRADITIONAL
+#
+# * InnoDB
+#
+# InnoDB is enabled by default with a 10MB datafile in /var/lib/mysql/.
+# Read the manual for more InnoDB related options. There are many!
+default_storage_engine	= InnoDB
+# you can't just change log file size, requires special procedure
+#innodb_log_file_size	= 50M
+innodb_buffer_pool_size	= 256M
+innodb_log_buffer_size	= 8M
+innodb_file_per_table	= 1
+innodb_open_files	= 400
+innodb_io_capacity	= 400
+innodb_flush_method	= O_DIRECT
+#
+# * Security Features
+#
+# Read the manual, too, if you want chroot!
+# chroot = /var/lib/mysql/
+#
+# For generating SSL certificates I recommend the OpenSSL GUI "tinyca".
+#
+# ssl-ca=/etc/mysql/cacert.pem
+# ssl-cert=/etc/mysql/server-cert.pem
+# ssl-key=/etc/mysql/server-key.pem
+
+#
+# * Galera-related settings
+#
+[galera]
+# Mandatory settings
+#wsrep_on=ON
+#wsrep_provider=
+#wsrep_cluster_address=
+#binlog_format=row
+#default_storage_engine=InnoDB
+#innodb_autoinc_lock_mode=2
+#
+# Allow server to accept connections on all interfaces.
+#
+#bind-address=0.0.0.0
+#
+# Optional setting
+#wsrep_slave_threads=1
+#innodb_flush_log_at_trx_commit=0
+
+[mysqldump]
+quick
+quote-names
+max_allowed_packet	= 16M
+
+[mysql]
+#no-auto-rehash	# faster start of mysql but no tab completion
+
+[isamchk]
+key_buffer_size		= 16M
+
+
+

--- a/init/30_set_config.sh
+++ b/init/30_set_config.sh
@@ -1,16 +1,26 @@
 #!/bin/bash
 
-mkdir -p config/{nginx/site-confs,www,log/mysql,log/nginx,keys} /var/run/php
+# make folders if required
+mkdir -p config/{nginx/site-confs,www,log/mysql,log/nginx,keys} /var/run/{php,mysqld}
 
+# configure mariadb
+sed -i 's/key_buffer\b/key_buffer_size/g' /etc/mysql/my.cnf
+sed -ri 's/^(bind-address|skip-networking)/;\1/' /etc/mysql/my.cnf
+sed -i s#/var/log/mysql#/config/log/mysql#g /etc/mysql/my.cnf
+sed -i -e 's/\(user.*=\).*/\1 abc/g' /etc/mysql/my.cnf
+sed -i -e "s#\(datadir.*=\).*#\1 $DATADIR#g" /etc/mysql/my.cnf
+sed -i "s/user='mysql'/user='abc'/g" /usr/bin/mysqld_safe
+
+# setup custom cnf file
+[[ ! -f /config/custom.cnf ]] && cp /defaults/my.cnf /config/custom.cnf
+[[ ! -L /etc/mysql/conf.d/custom.cnf && -f /etc/mysql/conf.d/custom.cnf ]] && rm /etc/mysql/conf.d/custom.cnf
+[[ ! -L /etc/mysql/conf.d/custom.cnf ]] && ln -s /config/custom.cnf /etc/mysql/conf.d/custom.cnf
+
+
+# configure nginx
 [[ ! -f /config/nginx/nginx.conf ]] && cp /defaults/nginx.conf /config/nginx/nginx.conf
-
 [[ ! -f /config/nginx/nginx-fpm.conf ]] && cp /defaults/nginx-fpm.conf /config/nginx/nginx-fpm.conf
-
 [[ ! -f /config/nginx/site-confs/default ]] && cp /defaults/default /config/nginx/site-confs/default
-
-[[ ! -d $DATADIR ]] && mkdir -p "$DATADIR"
-
-[[ ! -d /var/run/mysqld ]] && mkdir -p /var/run/mysql
 
 chown abc:abc /data
 chown -R abc:abc /config /var/run/php

--- a/init/60_initialise_database.sh
+++ b/init/60_initialise_database.sh
@@ -92,6 +92,6 @@ rm /tmp/mysql-first-time.sql
 fi
 
 crontab /defaults/owncloud
-
+chown -R abc:abc /config
 
 


### PR DESCRIPTION
mirrored changes to the mariadb container with config setup etc of the database element.
added extra config options to the nginx config for owncloud.

owncloud 9 though has introduced a little problem with port mappings.
if you don't change the port assignment of 443 then it works fine, but if you change it then there seems to be a bug in owncloud setup routine.
it should pass the ip address to the config as part of the trusted domains, it passes the ip plus the port and owncloud throws up an error about untrusted domain.
have to edit the config file manually and take out the port part of the entry for trusted domain..

grr, stupid clowncloud.
